### PR TITLE
Improve support for module-provided glue

### DIFF
--- a/docs/source/customizing.rst
+++ b/docs/source/customizing.rst
@@ -3,6 +3,8 @@ Customizing stackscope for your library
 
 .. currentmodule:: stackscope
 
+.. _customizing:
+
 `stackscope` contains several customization hooks that allow it to be
 adapted to provide good stack traces for context managers, awaitables,
 and control-flow primitives that it doesn't natively know anything about.

--- a/docs/source/customizing.rst
+++ b/docs/source/customizing.rst
@@ -18,17 +18,26 @@ If you're working with a library that could be better-supported by stackscope,
 you have two options for implementing that support:
 
 * If you maintain the library that the customizations are intended to
-  support, and you're willing to let your library take an optional
-  dependency on `stackscope`, then just ``import stackscope`` and
-  perform your customizations by registering hook implementations when
-  your library is imported. stackscope is a fairly lightweight import:
-  33ms on the author's laptop including standard-library dependencies.
+  support, then define a function named ``_stackscope_install_glue_``
+  at top level in any of your library's module(s), which takes no
+  arguments and returns None. The body of the function should register
+  customization hooks appropriate to your library, using the
+  stackscope APIs described in the rest of this section. As long as you
+  only write ``import stackscope`` inside the body of the glue installation
+  function, this won't require that users of your library install stackscope,
+  but they will benefit from your glue if they do.
 
-* If you're contributing glue for a library you don't maintain, or you're
-  not willing to import stackscope from your library, you can put the glue
-  in stackscope instead. We have glue for several modules and a system that
-  avoids registering it unless the module has been imported. See
-  ``stackscope/_glue.py``, and feel free to submit a PR.
+* If you're contributing glue for a library you don't maintain, you
+  can put the glue in stackscope instead. We have glue for several
+  modules and a system that avoids registering it unless the module
+  has been imported. See ``stackscope/_glue.py``, and feel free to
+  submit a PR.
+
+If the same module has glue implemented using both of these methods,
+then the glue provided by the module will be used; the glue
+shipped with stackscope is ignored. This allows for a module's glue to
+start out being shipped with stackscope and later "graduate" to being
+maintained upstream.
 
 Overview of customization hooks
 -------------------------------

--- a/newsfragments/7.feature.rst
+++ b/newsfragments/7.feature.rst
@@ -1,0 +1,5 @@
+A library can now ship its own :ref:`stackscope customizations <customizing>`
+without requiring that all of its users install stackscope. Any module may
+define a function called ``_stackscope_install_glue_()``, which stackscope will
+call when it is first used to extract a stack trace after the module has been
+imported.

--- a/stackscope/_glue.py
+++ b/stackscope/_glue.py
@@ -62,7 +62,6 @@ InstallGlueFn = Callable[[], None]
 builtin_glue_pending: Dict[str, InstallGlueFn] = {}
 
 
-
 def builtin_glue(needs_module: str) -> Callable[[InstallGlueFn], InstallGlueFn]:
     """Returns a decorator which marks the function it decorates as
     providing glue for *needs_module*. The decorated function will be

--- a/stackscope/_glue.py
+++ b/stackscope/_glue.py
@@ -62,7 +62,22 @@ InstallGlueFn = Callable[[], None]
 builtin_glue_pending: Dict[str, InstallGlueFn] = {}
 
 
+
 def builtin_glue(needs_module: str) -> Callable[[InstallGlueFn], InstallGlueFn]:
+    """Returns a decorator which marks the function it decorates as
+    providing glue for *needs_module*. The decorated function will be
+    called at most once, on the first attempt to extract a stack after
+    *needs_module* has been loaded, in order to set up customizations
+    that depend on that module.
+
+    Modules may also provide their own glue, by defining a top-level
+    function named ``_stackscope_install_glue_``. This function will
+    similarly be called at most once, on the first attempt to extract
+    a stack after the module defining it has been loaded. If both
+    module-provided and builtin glue exist for the same module, then
+    only the module-provided glue will run.
+    """
+
     def decorate(fn: InstallGlueFn) -> InstallGlueFn:
         assert needs_module not in builtin_glue_pending
         if needs_module in sys.modules and "sphinx" not in sys.modules:
@@ -74,31 +89,47 @@ def builtin_glue(needs_module: str) -> Callable[[InstallGlueFn], InstallGlueFn]:
     return decorate
 
 
-def add_glue_as_needed() -> None:
-    for module_name in list(builtin_glue_pending):
-        if module_name in sys.modules:
+glue_lock = threading.Lock()
+
+
+def add_glue_as_needed(*, _sys_modules_len_cache: list[int] = [0]) -> None:
+    if len(sys.modules) == _sys_modules_len_cache[0]:
+        return
+    # Use a lock to avoid races between multiple threads trying to extract
+    # tracebacks simultaneously
+    with glue_lock:
+        module_names = tuple(sys.modules)
+        for module_name in module_names:
+            builtin_fn = builtin_glue_pending.pop(module_name, None)
             try:
-                install_fn = builtin_glue_pending.pop(module_name)
-            except KeyError:
-                # Probably two simultaneous calls occurring in
-                # different threads; the effect of glue is global
-                # so just skip it under the assumption that
-                # someone else got this one.
-                pass
-            else:
-                try:
-                    install_fn()
-                except Exception as exc:
-                    warnings.warn(
-                        "Failed to initialize glue for {}: {}. Some tracebacks may be "
-                        "presented less crisply or with missing information.".format(
-                            module_name,
-                            "".join(
-                                traceback.format_exception_only(type(exc), exc)
-                            ).strip(),
-                        ),
-                        RuntimeWarning,
-                    )
+                module_fn = sys.modules[module_name].__dict__.pop(
+                    "_stackscope_install_glue_", None
+                )
+            except Exception:  # module disappeared, doesn't have a dict, etc
+                module_fn = None
+            try:
+                # Prefer the module-supplied glue over our builtin version
+                # in case both are present
+                if module_fn is not None:
+                    module_fn()
+                elif builtin_fn is not None:
+                    builtin_fn()
+            except Exception as exc:
+                kind = (
+                    "module-provided" if module_fn is not None else "stackscope-builtin"
+                )
+                exc_str = "".join(
+                    traceback.format_exception_only(type(exc), exc)
+                ).strip()
+                warnings.warn(
+                    f"Failed to initialize {kind} glue for {module_name}: {exc_str}. "
+                    "Some tracebacks may be presented less crisply or with "
+                    "missing information.",
+                    RuntimeWarning,
+                )
+        # Only update the length cache if we visited every module (rather
+        # than bailing out with an exception)
+        _sys_modules_len_cache[0] = len(module_names)
 
 
 functools_singledispatch_wrapper = get_code(functools.singledispatch, "wrapper")

--- a/stackscope/_tests/conftest.py
+++ b/stackscope/_tests/conftest.py
@@ -36,6 +36,9 @@ def local_registry():
     with ExitStack() as stack:
         stack.enter_context(save_restore_contents(builtin_glue_pending))
         stack.enter_context(save_restore_contents(cust.elaborate_frame.registry))
+        stack.enter_context(
+            save_restore_contents(cust.unwrap_context_generator.registry)
+        )
         for hook in each_singledispatch():
             stack.callback(hook._clear_cache)
             stack.enter_context(save_restore_contents(hook.registry))


### PR DESCRIPTION
stackscope will now locate and call a function named `_stackscope_install_glue_()` once per process for each module that defines one, in order to invoke module-provided logic for setting up stackscope customizations. This allows modules to support stackscope without depending on it.