### PR TITLE
Add support for recursing into child tasks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,10 @@ stack that led to the ``extract()`` call, then either pass a
 ``stackscope.StackSlice`` or use the convenience aliases
 ``stackscope.extract_since()`` and ``stackscope.extract_until()``.
 
+Trio users: Try ``print(stackscope.extract(trio.lowlevel.current_root_task(),
+recurse_child_tasks=True))`` to print the entire task tree of your
+Trio program.
+
 Once you have a ``Stack``, you can:
 
 * Format it for human consumption: ``str()`` obtains a tree view as

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -12,8 +12,8 @@ It comes in several variants:
 * :func:`extract` accepts a "stack item", which is anything stackscope
   knows how to turn into a series of frame objects. This might be a
   `StackSlice`, coroutine object, generator iterator, thread,
-  greenlet, or anything else for which a library author (maybe you)
-  have added support through the :func:`unwrap_stackitem`
+  greenlet, `trio.lowlevel.Task`, or anything else for which a library
+  author (maybe you) have added support through the :func:`unwrap_stackitem`
   customization hook.
 
 * :func:`extract_since` and :func:`extract_until` obtain a stack for
@@ -68,6 +68,12 @@ organize the data returned by :func:`extract`.
 
       The series of frames (individual calls) in the call stack,
       from outermost/oldest to innermost/newest.
+
+   .. autoattribute:: root
+
+      The object that was originally passed to :func:`extract` to produce
+      this stack trace, or `None` if the trace was created from a
+      `StackSlice` (which doesn't carry any information beyond the frames).
 
    .. autoattribute:: leaf
 
@@ -214,9 +220,11 @@ organize the data returned by :func:`extract`.
 
    .. autoattribute:: children
 
-      The other context managers nested inside this one, if applicable.
-      For example, an `~contextlib.ExitStack` will have one entry here
-      per thing that was pushed on the stack.
+      The other context managers or child task stacks that are
+      logically nested inside this one, if applicable.  For example,
+      an `~contextlib.ExitStack` will have one entry here per thing
+      that was pushed on the stack, and a `trio.Nursery` will have one
+      entry per child task running in the nursery.
 
    .. autoattribute:: hide
 

--- a/docs/source/customizing.rst
+++ b/docs/source/customizing.rst
@@ -175,6 +175,13 @@ Example: glue for handling generator-based `@contextmanager <contextlib.contextm
         context.description = f"{mgr.gen.__qualname__}(...)"
 
 
+Utilities for use in customization hooks
+----------------------------------------
+
+.. autofunction:: extract_child
+.. autofunction:: fill_context
+
+
 Customization hooks reference
 -----------------------------
 
@@ -192,4 +199,3 @@ Customization hooks reference
 .. autofunction:: unwrap_context
 .. autofunction:: unwrap_context_generator
 .. autofunction:: elaborate_context
-.. autofunction:: fill_context

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,10 @@ stack that led to the :func:`extract` call, then either pass a
 `stackscope.StackSlice` or use the convenience aliases
 :func:`extract_since` and :func:`extract_until`.
 
+Trio users: Try ``print(stackscope.extract(trio.lowlevel.current_root_task(),
+recurse_child_tasks=True))`` to print the entire task tree of your
+Trio program.
+
 Once you have a `Stack`, you can:
 
 * Format it for human consumption: ``str()`` obtains a tree view as

--- a/newsfragments/9.feature.rst
+++ b/newsfragments/9.feature.rst
@@ -1,0 +1,18 @@
+Added support for representing child tasks in structured concurrency libraries,
+by allowing `Context.children` to contain `Stack`\s in addition to the
+existing support for child `Context`\s. By default, the child tasks will
+not have their frames filled out, but you can override this with the new
+*recurse_child_tasks* parameter to :func:`extract`.
+
+Added a new attribute `Stack.root` which preserves the original "stack item"
+object that was passed to :func:`extract`. For stacks generated from async
+child tasks, this will be the ``Task`` object.
+
+Added a new function :func:`extract_child` for use in customization hooks.
+It is like :func:`extract` except that it reuses the options that were
+specified for the outer :func:`extract` call, and contains some additional
+logic to prune child task frames if the outer :func:`extract` didn't ask
+for them.
+
+Updated Trio glue to support unwrapping `trio.lowlevel.Task`\s and filling
+in the child tasks of a `trio.Nursery`.

--- a/newsfragments/9.misc.rst
+++ b/newsfragments/9.misc.rst
@@ -1,0 +1,4 @@
+The :func:`unwrap_context` and :func:`unwrap_context_generator` hooks now
+accept an additional `Context` argument. This saves on duplicated effort
+between :func:`elaborate_context` and :func:`unwrap_context`, avoiding
+exponential time complexity in some pathological cases.

--- a/stackscope/_customization.py
+++ b/stackscope/_customization.py
@@ -37,7 +37,6 @@ __all__ = [
     "unwrap_context_generator",
     "elaborate_context",
     "customize",
-    "fill_context",
     "yields_frames",
     "PRUNE",
 ]
@@ -148,9 +147,11 @@ def elaborate_frame(
 @functools.singledispatch
 def unwrap_context(
     manager: ContextManager[Any] | AsyncContextManager[Any],
+    context: Context,
 ) -> None | ContextManager[Any] | AsyncContextManager[Any] | tuple[()]:
     """Hook for extracting an inner context manager from another
-    context manager that wraps it. Return None if there is no further
+    context manager that wraps it. The stackscope *context* object is
+    also provided in case it's useful. Return None if there is no further
     unwrapping to do. Return `PRUNE` (equivalent to an empty tuple)
     to hide this context manager from the traceback. Unlike
     :func:`unwrap_stackitem`, it is not currently supported to let the
@@ -173,16 +174,22 @@ def _code_of_first_frame(stack: Stack) -> types.CodeType:
     return stack.frames[0].pyframe.f_code
 
 
-@code_dispatch(_code_of_first_frame)
+@code_dispatch(_code_of_frame)
 def unwrap_context_generator(
-    inner_stack: Stack,
+    frame: Frame, context: Context
 ) -> None | ContextManager[Any] | AsyncContextManager[Any] | tuple[()]:
-    """Hook for extracting an inner context manager from the
-    *inner_stack* of a generator-based context manager that wraps it.
-    This hook uses `@code_dispatch <stackscope.lowlevel.code_dispatch>`,
-    so it can be customized based on the identity of the function that
-    implements the context manager (the outermost frame in *inner_stack*).
-    Apart from that, its semantics are equivalent to :func:`unwrap_context`.
+    """Hook for extracting an inner context manager from the outermost
+    *frame* of a generator-based context manager that wraps it.  This
+    hook uses `@code_dispatch <stackscope.lowlevel.code_dispatch>`, so
+    it can be customized based on the identity of the function that
+    implements the context manager.  Apart from that, its semantics
+    are equivalent to :func:`unwrap_context`.
+
+    .. note:: If the context manager you're unwrapping uses ``yield from``,
+       it's possible that you'll need to access callees of *frame* to
+       implement your logic. You can find these using `Context.inner_stack`,
+       or if that's None because the context is currently exiting, you can
+       reconstruct it using ``stackscope.extract(context.obj.gen)``.
     """
     return None
 
@@ -198,33 +205,6 @@ def elaborate_context(
     the provided *manager* (the actual context manager, i.e., the thing
     whose type has ``__enter__`` and ``__exit__`` attributes).
     """
-
-
-def fill_context(context: Context) -> None:
-    """Augment the given newly-constructed `Context` object using the
-    context manager hooks (:func:`unwrap_context` and :func:`elaborate_context`),
-    calling both hooks in a loop until a steady state is reached.
-    """
-    for _ in range(100):
-        if TYPE_CHECKING:
-            from typing import ContextManager, AsyncContextManager
-
-            assert isinstance(context.obj, (ContextManager, AsyncContextManager))
-        elaborate_context(context.obj, context)
-        inner_mgr = unwrap_context(context.obj)
-        if inner_mgr is None:
-            break
-        if inner_mgr == PRUNE:
-            context.hide = True
-            break
-        context.obj = inner_mgr
-    else:
-        inner_mgr = unwrap_context(context.obj)  # type: ignore
-        raise RuntimeError(
-            f"{context.obj!r} has been unwrapped more than 100 times "
-            f"without reaching something irreducible; probably an "
-            f"infinite loop? (next result is {inner_mgr!r})"
-        )
 
 
 @overload

--- a/stackscope/_customization.py
+++ b/stackscope/_customization.py
@@ -167,13 +167,6 @@ def unwrap_context(
     return None
 
 
-def _code_of_first_frame(stack: Stack) -> types.CodeType:
-    if not stack.frames:
-        # arbitrary code object that no one will register
-        return _code_of_first_frame.__code__
-    return stack.frames[0].pyframe.f_code
-
-
 @code_dispatch(_code_of_frame)
 def unwrap_context_generator(
     frame: Frame, context: Context

--- a/stackscope/_extract.py
+++ b/stackscope/_extract.py
@@ -47,7 +47,12 @@ from . import _glue
 
 
 __all__ = [
-    "extract", "extract_outermost", "extract_since", "extract_until", "extract_child", "fill_context",
+    "extract",
+    "extract_outermost",
+    "extract_since",
+    "extract_until",
+    "extract_child",
+    "fill_context",
 ]
 
 

--- a/stackscope/_extract.py
+++ b/stackscope/_extract.py
@@ -8,14 +8,17 @@ import gc
 import inspect
 import itertools
 import sys
+import threading
 import types
 import weakref
+from contextlib import contextmanager
 from typing import (
     Any,
     Callable,
     Deque,
     Generator,
     Iterable,
+    Iterator,
     List,
     Optional,
     Sequence,
@@ -23,6 +26,7 @@ from typing import (
     TypeVar,
     Union,
     TYPE_CHECKING,
+    cast,
 )
 
 if sys.version_info < (3, 11):
@@ -35,7 +39,6 @@ from ._customization import (
     elaborate_frame,
     unwrap_context,
     elaborate_context,
-    fill_context,
     FrameIterator,
     PRUNE,
 )
@@ -43,7 +46,9 @@ from ._lowlevel import contexts_active_in_frame
 from . import _glue
 
 
-__all__ = ["extract", "extract_outermost", "extract_since", "extract_until"]
+__all__ = [
+    "extract", "extract_outermost", "extract_since", "extract_until", "extract_child", "fill_context",
+]
 
 
 def better_origin(candidate: object, fallback: object) -> object:
@@ -60,10 +65,26 @@ def better_origin(candidate: object, fallback: object) -> object:
         return fallback
 
 
+class ExtractOptions(threading.local):
+    with_contexts: bool = cast(bool, None)
+    recurse_child_tasks: bool = cast(bool, None)
+
+    @contextmanager
+    def push(self, *, with_contexts: bool, recurse_child_tasks: bool) -> Iterator[None]:
+        prev = (self.with_contexts, self.recurse_child_tasks)
+        self.with_contexts = with_contexts
+        self.recurse_child_tasks = recurse_child_tasks
+        try:
+            yield
+        finally:
+            (self.with_contexts, self.recurse_child_tasks) = prev
+
+
+current_options = ExtractOptions()
+
+
 def extract_iter(
-    stackitem: StackItem,
-    save_errors: List[Exception],
-    with_contexts: bool,
+    stackitem: StackItem, save_errors: List[Exception]
 ) -> Generator[Frame, None, StackItem]:
     """Implements the common logic of extract() and extract_outermost().
 
@@ -72,6 +93,7 @@ def extract_iter(
     traversal are saved to the list *save_errors*.
     """
 
+    assert current_options.with_contexts is not None
     _glue.add_glue_as_needed()
 
     # to_unwrap items are (origin, stackitem, depth)
@@ -164,7 +186,7 @@ def extract_iter(
         assert isinstance(frame, Frame)
         next_inner = to_elaborate[0][0] if to_elaborate else None
 
-        if with_contexts:
+        if current_options.with_contexts:
             next_pyframe = next_inner.pyframe if isinstance(next_inner, Frame) else None
             try:
                 frame.contexts = contexts_active_in_frame(
@@ -219,7 +241,12 @@ def extract_iter(
     return None
 
 
-def extract(stackitem: StackItem, *, with_contexts: bool = True) -> Stack:
+def extract(
+    stackitem: StackItem,
+    *,
+    with_contexts: bool = True,
+    recurse_child_tasks: bool = False,
+) -> Stack:
     """Extract a `Stack` from *stackitem*.
 
     *stackitem* may be anything that has a stack associated with it.
@@ -239,14 +266,51 @@ def extract(stackitem: StackItem, *, with_contexts: bool = True) -> Stack:
     don't care about this information, then specifying ``with_contexts=False``
     will substantially simplify the stack extraction process.
 
+    Some context managers might logically contain other tasks that
+    each have their own `Stack`: `trio.Nursery`, `asyncio.TaskGroup`,
+    etc. These will be listed as `Context.children` in the returned
+    `Frame.contexts` for these context managers. If
+    *recurse_child_tasks* is False (the default), then these "child
+    tasks" will be rendered as stub `Stack` objects with only a
+    `~Stack.root` (the child task object) but no `~Stack.frames`. If
+    *recurse_child_tasks* is True, then the child stacks will be fully
+    populated, including grandchildren and so on.
+
     :func:`extract` tries not to throw exceptions; any exception should
     be reported as a bug. Errors encountered during stack extraction
     are reported in the `~Stack.error` attribute of the returned
     object. If multiple errors are encountered, they will be wrapped in
     an `ExceptionGroup`.
+
     """
+    with current_options.push(
+        with_contexts=with_contexts, recurse_child_tasks=recurse_child_tasks
+    ):
+        return extract_child(stackitem, for_task=False)
+
+
+def extract_child(stackitem: StackItem, *, for_task: bool) -> Stack:
+    """Perform a recursive call equivalent to ``extract(stackitem)``, but
+    reusing the options that were passed to the original ``extract()``.
+    You should only call this from within a :ref:`customization hook
+    <customizing>` such as :func:`elaborate_context`.
+
+    If *for_task* is True, then this nested *stackitem* is considered to
+    represent an async child task. Its stack will be fully extracted only
+    if the outer ``extract()`` call specified ``recurse_child_tasks=True``;
+    otherwise you will get a stub `Stack` with a `~Stack.root` but no
+    `~Stack.frames`.
+    """
+    if current_options.recurse_child_tasks is None:
+        raise RuntimeError(
+            "extract_child() may only be called from within a customization "
+            "hook invoked by extract()"
+        )
+    if for_task and not current_options.recurse_child_tasks:
+        return Stack(root=stackitem, frames=[])
+
     errors: List[Exception] = []
-    it = extract_iter(stackitem, errors, with_contexts=with_contexts)
+    it = extract_iter(stackitem, errors)
     frames = []
     while True:
         try:
@@ -259,10 +323,20 @@ def extract(stackitem: StackItem, *, with_contexts: bool = True) -> Stack:
                 )
             else:
                 error = errors[0] if errors else None
-            return Stack(frames=frames, leaf=ex.value, error=error)
+            return Stack(
+                root=(None if isinstance(stackitem, StackSlice) else stackitem),
+                frames=frames,
+                leaf=ex.value,
+                error=error,
+            )
 
 
-def extract_outermost(stackitem: StackItem, *, with_contexts: bool = True) -> Frame:
+def extract_outermost(
+    stackitem: StackItem,
+    *,
+    with_contexts: bool = True,
+    recurse_child_tasks: bool = False,
+) -> Frame:
     """Extract the outermost `Frame` from *stackitem*.
 
     :func:`extract_outermost` produces the same result as calling :func:`extract`
@@ -271,28 +345,34 @@ def extract_outermost(stackitem: StackItem, *, with_contexts: bool = True) -> Fr
     no `Frame`\\s, an exception will be thrown.
     """
 
-    errors: List[Exception] = []
-    try:
-        return next(extract_iter(stackitem, errors, with_contexts=with_contexts))
-    except StopIteration as ex:
-        if len(errors) > 1:  # pragma: no cover
-            # Rationale for 'no cover': as currently written, only one error can
-            # be saved while unwrapping, and errors raised at other points wouldn't
-            # reach here because a frame would be available
-            raise ExceptionGroup(
-                "multiple errors encountered while extracting stack", errors
-            )
-        if errors:
-            raise errors[0]
-        else:
-            raise RuntimeError(
-                f"Couldn't extract a frame from {stackitem!r}: unwrapping only "
-                f"reached {ex.value!r}"
-            )
+    with current_options.push(
+        with_contexts=with_contexts, recurse_child_tasks=recurse_child_tasks
+    ):
+        errors: List[Exception] = []
+        try:
+            return next(extract_iter(stackitem, errors))
+        except StopIteration as ex:
+            if len(errors) > 1:  # pragma: no cover
+                # Rationale for 'no cover': as currently written, only one error can
+                # be saved while unwrapping, and errors raised at other points wouldn't
+                # reach here because a frame would be available
+                raise ExceptionGroup(
+                    "multiple errors encountered while extracting stack", errors
+                )
+            if errors:
+                raise errors[0]
+            else:
+                raise RuntimeError(
+                    f"Couldn't extract a frame from {stackitem!r}: unwrapping only "
+                    f"reached {ex.value!r}"
+                )
 
 
 def extract_since(
-    outer_frame: Optional[types.FrameType], *, with_contexts: bool = True
+    outer_frame: Optional[types.FrameType],
+    *,
+    with_contexts: bool = True,
+    recurse_child_tasks: bool = False,
 ) -> Stack:
     """Return a `Stack` reflecting the currently-executing frames that were
     directly or indirectly called by *outer_frame*, including *outer_frame* itself.
@@ -326,7 +406,11 @@ def extract_since(
     """
     if outer_frame is not None and not isinstance(outer_frame, types.FrameType):
         raise TypeError(f"outer_frame must be a frame, not {type(outer_frame)!r}")
-    return extract(StackSlice(outer=outer_frame))
+    return extract(
+        StackSlice(outer=outer_frame),
+        with_contexts=with_contexts,
+        recurse_child_tasks=recurse_child_tasks,
+    )
 
 
 def extract_until(
@@ -334,6 +418,7 @@ def extract_until(
     *,
     limit: Union[int, types.FrameType, None] = None,
     with_contexts: bool = True,
+    recurse_child_tasks: bool = False,
 ) -> Stack:
     """Return a `Stack` reflecting the currently executing frames that are
     direct or indirect callers of *inner_frame*, including
@@ -357,6 +442,7 @@ def extract_until(
     its inputs (an exception will be raised if *limit* has an invalid type
     or is a frame that isn't an indirect caller of *inner_frame*).
     """
+    opts = {"with_contexts": with_contexts, "recurse_child_tasks": recurse_child_tasks}
     if isinstance(limit, types.FrameType):
         outer_frame: Optional[types.FrameType] = inner_frame
         while (
@@ -369,10 +455,46 @@ def extract_until(
             outer_frame = outer_frame.f_back
         if outer_frame is None:
             raise RuntimeError(f"{limit} is not an indirect caller of {inner_frame}")
-        return extract(StackSlice(outer=outer_frame, inner=inner_frame))
+        return extract(StackSlice(outer=outer_frame, inner=inner_frame), **opts)
     elif isinstance(limit, int) or limit is None:
-        return extract(StackSlice(inner=inner_frame, limit=limit))
+        return extract(StackSlice(inner=inner_frame, limit=limit), **opts)
     else:
         raise TypeError(
             f"'limit' argument must be a frame or integer, not {type(limit)!r}"
+        )
+
+
+def fill_context(context: Context) -> None:
+    """Augment the given newly-constructed `Context` object using the
+    context manager hooks (:func:`unwrap_context` and :func:`elaborate_context`),
+    calling both hooks in a loop until a steady state is reached.
+    """
+    if current_options.with_contexts is None:
+        # Allow fill_context() to be used outside an extract() call, even
+        # though the hooks it's calling might assume they're inside extract()
+        with current_options.push(with_contexts=True, recurse_child_tasks=False):
+            fill_context(context)
+        return
+
+    for _ in range(100):
+        if TYPE_CHECKING:
+            from typing import ContextManager, AsyncContextManager
+
+            assert isinstance(context.obj, (ContextManager, AsyncContextManager))
+        elaborate_context(context.obj, context)
+        inner_mgr = unwrap_context(context.obj, context)
+        if inner_mgr is None:
+            break
+        if inner_mgr == PRUNE:
+            context.hide = True
+            break
+        context.obj = inner_mgr
+        context.inner_stack = None
+        context.children = ()
+    else:
+        inner_mgr = unwrap_context(context.obj, context)  # type: ignore
+        raise RuntimeError(
+            f"{context.obj!r} has been unwrapped more than 100 times "
+            f"without reaching something irreducible; probably an "
+            f"infinite loop? (next result is {inner_mgr!r})"
         )

--- a/stackscope/_tests/test_registry.py
+++ b/stackscope/_tests/test_registry.py
@@ -212,9 +212,5 @@ def test_glue_error(local_registry, monkeypatch):
         stackscope._glue.add_glue_as_needed()
 
 
-def test_unwrap_nothing():
-    assert stackscope.unwrap_context_generator(stackscope.Stack([])) is None
-
-
 def test_prune():
     repr(stackscope.PRUNE)

--- a/stackscope/_types.py
+++ b/stackscope/_types.py
@@ -507,7 +507,7 @@ class Context(Formattable):
                     if not did_blank:
                         lines.append(continue_child + "\n")
                     sublines.append("\n")
-            did_blank = sublines and not sublines[-1].strip()
+            did_blank = bool(sublines and not sublines[-1].strip())
             for idx, line in enumerate(sublines):
                 marker = start_child if idx == 0 else continue_child
                 lines.append(marker + line)


### PR DESCRIPTION
This makes stackscope suitable on its own as a Trio task tree printer.