### PR TITLE
Close the temporary async generator used to locate the asend/athrow types

### DIFF
--- a/newsfragments/12.bugfix.rst
+++ b/newsfragments/12.bugfix.rst
@@ -1,0 +1,3 @@
+The first invocation of :func:`stackscope.extract` no longer leaves a
+partially-exhausted async generator object to be garbage collected,
+which previously could confuse async generator finalization hooks.

--- a/stackscope/_glue.py
+++ b/stackscope/_glue.py
@@ -307,7 +307,7 @@ def glue_builtins() -> None:
     athrow_type = type(agen.athrow(ValueError))
     try:
         # Clean up the asyncgen so it doesn't confuse any finalization hooks
-        agen.aclose().send(None)
+        agen.aclose().send(None)  # type: ignore
     except (StopIteration, StopAsyncIteration):
         pass
 

--- a/stackscope/_glue.py
+++ b/stackscope/_glue.py
@@ -302,8 +302,14 @@ def glue_builtins() -> None:
 
     # Get the types of the internal awaitables used in native async
     # generator asend/athrow calls
-    asend_type = type(some_asyncgen().asend(None))
-    athrow_type = type(some_asyncgen().athrow(ValueError))
+    agen = some_asyncgen()
+    asend_type = type(agen.asend(None))
+    athrow_type = type(agen.athrow(ValueError))
+    try:
+        # Clean up the asyncgen so it doesn't confuse any finalization hooks
+        agen.aclose().send(None)
+    except (StopIteration, StopAsyncIteration):
+        pass
 
     async def some_afn() -> None:
         pass  # pragma: no cover


### PR DESCRIPTION
This resolves a spurious invocation of the async generator hooks on the first call to `stackscope.extract()`.